### PR TITLE
Bug regarding name handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,4 @@
+optimaladj 0.0.4
+==============
+
+* Fixed a bug reported by Sara Taheri, whereby due to mishandling of node names we could end up including forbidden variables in an adjustment set.

--- a/optimaladj/CausalGraph.py
+++ b/optimaladj/CausalGraph.py
@@ -113,9 +113,9 @@ class CausalGraph(nx.DiGraph):
         forbidden = set()
 
         for node in self.causal_vertices(treatment, outcome):
-            forbidden = forbidden.union(nx.descendants(self, node).union(node))
+            forbidden = forbidden.union(nx.descendants(self, node).union({node}))
 
-        return forbidden.union(treatment)
+        return forbidden.union({treatment})
 
     def ignore(self, treatment, outcome, L, N):
         """Returns the set of ignorable vertices with respect to treatment, outcome,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="optimaladj",
-    version="0.0.3",
+    version="0.0.4",
     author="Facundo Sapienza, Ezequiel Smucler",
     author_email="ezequiels.90@gmail.com",
     description="A package to compute optimal adjustment sets in causal graphs",

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -339,6 +339,7 @@ outcome_9 = "Y"
 G_9.add_nodes_from(costs_9)
 G_9.add_edges_from(
     [
+        ("A", "Y"),
         ("K", "A"),
         ("W1", "K"),
         ("W2", "K"),
@@ -362,3 +363,31 @@ OPTIMALS.append(set(["O", "W7", "W8", "W9"]))
 OPTIMALS_MINIMAL.append(set(["W7", "W8", "W9"]))
 OPTIMALS_MINIMUM.append(set(["K"]))
 OPTIMALS_MINCOST.append(set(["W7", "W8", "W6"]))
+
+# Regression test for bug on name handling, spotted by Sara Taheri
+
+G_10 = CausalGraph()
+L_10 = []
+N_10 = ["T", "Y", "M1", "M2", "Z1", "Z2", "Z3"]
+costs_10 = [(node, {"cost": 1}) for node in N_10]
+treatment_10 = "T"
+outcome_10 = "Y"
+G_10.add_nodes_from(costs_10)
+G_10.add_edges_from(
+    [
+        ("Z1", "Z2"),
+        ("Z1", "T"),
+        ("Z2", "Z3"),
+        ("Z3", "Y"),
+        ("T", "M1"),
+        ("M1", "M2"),
+        ("M2", "Y"),
+    ]
+)
+
+EXAMPLES.append(CausalGraphExample(G_10, treatment_10, outcome_10, L_10, N_10))
+
+OPTIMALS.append(set(["Z3"]))
+OPTIMALS_MINIMAL.append(set(["Z3"]))
+OPTIMALS_MINIMUM.append(set(["Z3"]))
+OPTIMALS_MINCOST.append(set(["Z3"]))

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -391,3 +391,38 @@ OPTIMALS.append(set(["Z3"]))
 OPTIMALS_MINIMAL.append(set(["Z3"]))
 OPTIMALS_MINIMUM.append(set(["Z3"]))
 OPTIMALS_MINCOST.append(set(["Z3"]))
+
+# Another regression test for bug on name handling, spotted by Sara Taheri
+
+G_11 = CausalGraph()
+L_11 = []
+N_11 = ["T", "Y", "M1", "M2", "M3", "Z1", "Z2", "Z3", "Z4", "Z5"]
+costs_11 = [(node, {"cost": 1}) for node in N_11]
+treatment_11 = "T"
+outcome_11 = "Y"
+G_11.add_nodes_from(costs_11)
+G_11.add_edges_from(
+    [
+        ("Z1", "Z2"),
+        ("Z1", "T"),
+        ("Z2", "Z3"),
+        ("Z3", "Z4"),
+        ("Z4", "Z5"),
+        ("Z5", "Y"),
+        ("T", "M1"),
+        ("M1", "M2"),
+        ("M2", "M3"),
+        ("M3", "Y"),
+        ("U1", "Z1"),
+        ("U1", "T"),
+        ("U2", "Z2"),
+        ("U2", "M1"),
+    ]
+)
+
+EXAMPLES.append(CausalGraphExample(G_11, treatment_11, outcome_11, L_11, N_11))
+
+OPTIMALS.append(set(["Z1", "Z2", "Z5"]))
+OPTIMALS_MINIMAL.append(set(["Z1"]))
+OPTIMALS_MINIMUM.append(set(["Z1"]))
+OPTIMALS_MINCOST.append(set(["Z1"]))

--- a/tests/test_CausalGraph.py
+++ b/tests/test_CausalGraph.py
@@ -42,7 +42,7 @@ def test_no_adj_minimum_optimal(example=EXAMPLES[0]):
 
 @pytest.mark.parametrize(
     "example, optimal_stored",
-    zip(EXAMPLES[1:4] + [EXAMPLES[8]], OPTIMALS[1:4] + [OPTIMALS[8]]),
+    zip(EXAMPLES[1:4] + EXAMPLES[8:11], OPTIMALS[1:4] + OPTIMALS[8:11]),
 )
 def test_optimal(example, optimal_stored):
     optimal = example.G.optimal_adj_set(
@@ -63,7 +63,7 @@ def test_optimal_failure(example):
 
 
 @pytest.mark.parametrize(
-    "example, optimal_minimal_stored", zip(EXAMPLES[1:8], OPTIMALS_MINIMAL[1:8])
+    "example, optimal_minimal_stored", zip(EXAMPLES[1:11], OPTIMALS_MINIMAL[1:11])
 )
 def test_optimal_minimal(example, optimal_minimal_stored):
     optimal = example.G.optimal_minimal_adj_set(
@@ -73,7 +73,7 @@ def test_optimal_minimal(example, optimal_minimal_stored):
 
 
 @pytest.mark.parametrize(
-    "example, optimal_minimum_stored", zip(EXAMPLES[1:8], OPTIMALS_MINIMUM[1:8])
+    "example, optimal_minimum_stored", zip(EXAMPLES[1:11], OPTIMALS_MINIMUM[1:11])
 )
 def test_optimal_minimum(example, optimal_minimum_stored):
     optimal = example.G.optimal_minimum_adj_set(
@@ -83,7 +83,7 @@ def test_optimal_minimum(example, optimal_minimum_stored):
 
 
 @pytest.mark.parametrize(
-    "example, optimal_mincost_stored", zip(EXAMPLES[1:8], OPTIMALS_MINCOST[1:8])
+    "example, optimal_mincost_stored", zip(EXAMPLES[1:11], OPTIMALS_MINCOST[1:11])
 )
 def test_optimal_mincost(example, optimal_mincost_stored):
     optimal = example.G.optimal_mincost_adj_set(

--- a/tests/test_CausalGraph.py
+++ b/tests/test_CausalGraph.py
@@ -42,7 +42,7 @@ def test_no_adj_minimum_optimal(example=EXAMPLES[0]):
 
 @pytest.mark.parametrize(
     "example, optimal_stored",
-    zip(EXAMPLES[1:4] + EXAMPLES[8:11], OPTIMALS[1:4] + OPTIMALS[8:11]),
+    zip(EXAMPLES[1:4] + EXAMPLES[8:12], OPTIMALS[1:4] + OPTIMALS[8:12]),
 )
 def test_optimal(example, optimal_stored):
     optimal = example.G.optimal_adj_set(
@@ -63,7 +63,7 @@ def test_optimal_failure(example):
 
 
 @pytest.mark.parametrize(
-    "example, optimal_minimal_stored", zip(EXAMPLES[1:11], OPTIMALS_MINIMAL[1:11])
+    "example, optimal_minimal_stored", zip(EXAMPLES[1:12], OPTIMALS_MINIMAL[1:12])
 )
 def test_optimal_minimal(example, optimal_minimal_stored):
     optimal = example.G.optimal_minimal_adj_set(
@@ -73,7 +73,7 @@ def test_optimal_minimal(example, optimal_minimal_stored):
 
 
 @pytest.mark.parametrize(
-    "example, optimal_minimum_stored", zip(EXAMPLES[1:11], OPTIMALS_MINIMUM[1:11])
+    "example, optimal_minimum_stored", zip(EXAMPLES[1:12], OPTIMALS_MINIMUM[1:12])
 )
 def test_optimal_minimum(example, optimal_minimum_stored):
     optimal = example.G.optimal_minimum_adj_set(
@@ -83,7 +83,7 @@ def test_optimal_minimum(example, optimal_minimum_stored):
 
 
 @pytest.mark.parametrize(
-    "example, optimal_mincost_stored", zip(EXAMPLES[1:11], OPTIMALS_MINCOST[1:11])
+    "example, optimal_mincost_stored", zip(EXAMPLES[1:12], OPTIMALS_MINCOST[1:12])
 )
 def test_optimal_mincost(example, optimal_mincost_stored):
     optimal = example.G.optimal_mincost_adj_set(


### PR DESCRIPTION
Sara Taheri pointed out the package was giving the wrong answer in the following simple example:

```
treatment = 'T'
outcome = 'Y'

L = []
N = ['T', 'Z1', 'Z2', 'Z3', 'M1', 'M2', 'Y']

G = CausalGraph()
G.add_edges_from([('Z1', 'Z2'),
                  ('Z1', 'T'),
                  ('Z2', 'Z3'),
                  ('Z3', 'Y'),
                  ('T', 'M1'),
                  ('M1','M2'),
                  ('M2', 'Y')])

G.ignore(treatment, outcome, L, N)
```

The output should be M1, M2, and it is only M2. This is due to a bug in the method that constructs the forbidden set, specifically [here](https://github.com/facusapienza21/optimaladj/pull/5/files#diff-b2d9d25afc3e9217a2dfa613c01444aa4d3e85177f53785a28decafdef1444fcL116). The problem is that when node has more than one character, each separate character is added to the forbidden set, instead of the whole string.

This PR fixes this and adds a test.